### PR TITLE
feat: API refactor and option to switch to specific workspacegroup

### DIFF
--- a/src/commands/alttab.lua
+++ b/src/commands/alttab.lua
@@ -38,8 +38,8 @@ end
 function shared.activate()
     local address = shared.selected_address
     utils.debug("Activating " .. address)
-    hyprland.exec_hyprctl_batch(
-        string.format("dispatch focuswindow address:%s", address),
+    hyprland.hyprctl_batch(
+        "dispatch focuswindow address:" .. address,
         "dispatch alterzorder top"
     )
 end

--- a/src/commands/alttab_ui.lua
+++ b/src/commands/alttab_ui.lua
@@ -5,8 +5,9 @@ local Gtk = lgi.require('Gtk', '3.0')
 local Gdk = lgi.require('Gdk', '3.0')
 local GdkPixbuf = lgi.require('GdkPixbuf', '2.0')
 local GLib = lgi.GLib
-local utils = require('lib.utils')
 local config = require('lib.config')
+local hyprland = require('lib.hyprland')
+local utils = require('lib.utils')
 
 local tiles = {}
 local prev_tile = 0
@@ -24,7 +25,7 @@ end
 
 local function cleanup()
     utils.debug("Cleaning up")
-    utils.exec_cmd("hyprctl dispatch submap reset")
+    hyprland.hyprctl("dispatch submap reset")
 end
 
 function alttab_ui.launch(params)
@@ -298,7 +299,7 @@ function alttab_ui.launch(params)
     end
 
     function app:on_activate()
-        utils.exec_cmd("hyprctl dispatch submap alttab")
+        hyprland.hyprctl("dispatch submap alttab")
 
         local dummywin = Gtk.ApplicationWindow {
             application = app,

--- a/src/commands/center.lua
+++ b/src/commands/center.lua
@@ -20,7 +20,7 @@ return function(args)
     local new_x = screen.x + math.floor((screen.w - new_w) / 2)
     local new_y = screen.y + math.floor((screen.h - new_h) / 2)
 
-    hyprland.exec_hyprctl_batch(
+    hyprland.hyprctl_batch(
         "dispatch fullscreenstate 0",
         string.format("dispatch moveactive exact %d %d", new_x, new_y),
         string.format("dispatch resizeactive exact %d %d", new_w, new_h),

--- a/src/commands/events.lua
+++ b/src/commands/events.lua
@@ -3,7 +3,7 @@ local event_loop = require("lib.event_loop")
 local posix = require("posix")
 
 return function(args)
-    local hyprsock = hyprland.get_hyprsocket()
+    local hyprsock = hyprland.get_hyprsocket('socket2')
     local loop = event_loop.create()
 
     print("\nListening for Hyprland events, press CTRL-C to exit...\n")

--- a/src/commands/movemon.lua
+++ b/src/commands/movemon.lua
@@ -15,7 +15,7 @@ return function(args)
     if nextmon < 0 then nextmon = moncount - 1 end
     if nextmon >= moncount then nextmon = 0 end
 
-    utils.exec_cmd(string.format("hyprctl dispatch movewindow mon:%d", nextmon))
+    hyprland.hyprctl("dispatch movewindow mon:" .. nextmon)
 
     local new = hyprland.get_active_context()
     if not new or new.window.monitor == old.window.monitor then
@@ -68,7 +68,7 @@ return function(args)
 
     new_x, new_y, new_w, new_h = hyprland.clamp_window_to_area(new_x, new_y, new_w, new_h, new_effective)
 
-    hyprland.exec_hyprctl_batch(
+    hyprland.hyprctl_batch(
         "dispatch fullscreenstate 0",
         string.format("dispatch moveactive exact %d %d", new_x, new_y),
         string.format("dispatch resizeactive exact %d %d", new_w, new_h),

--- a/src/commands/overview.lua
+++ b/src/commands/overview.lua
@@ -33,7 +33,7 @@ return function(args)
     assert(ok, "Failed to bind control socket: " .. (err or "unknown error"))
     posix.listen(listenfd, 1)
 
-    local hyprsock = hyprland.get_hyprsocket()
+    local hyprsock = hyprland.get_hyprsocket('socket2')
     local clients = hyprland.get_clients()
     local monitors = hyprland.get_monitors()
     local workspaces = hyprland.get_workspaces()
@@ -44,11 +44,11 @@ return function(args)
     local opt_commands = {}
     for _, opt in ipairs(cfg.options) do
         local key, newval = opt:match("^([^%s]+)%s*(.*)")
-        local origval = utils.get_cmd_json(string.format("hyprctl getoption %s -j", key))
+        local origval = hyprland.hyprctl_json(string.format("getoption %s", key))
         table.insert(orig_options, origval)
         table.insert(opt_commands, string.format("keyword %s %s", key, newval))
     end
-    hyprland.exec_hyprctl_batch(table.unpack(opt_commands))
+    hyprland.hyprctl_batch(table.unpack(opt_commands))
 
     -- Save all window states
     local active_window = hyprland.get_activewindow()
@@ -169,13 +169,11 @@ return function(args)
                 table.insert(grid_commands, string.format("dispatch resizeactive exact %d %d", win_w, win_h))
             end
         end
-
-        ::continue::
     end
 
     -- restore original active window focus
     table.insert(grid_commands, string.format("dispatch focuswindow address:%s", active_window.address))
-    hyprland.exec_hyprctl_batch(table.unpack(grid_commands))
+    hyprland.hyprctl_batch(table.unpack(grid_commands))
 
     local function restore_options()
         local opt_commands = {}
@@ -186,7 +184,7 @@ return function(args)
 
             table.insert(opt_commands, string.format("keyword %s %s", opt.option, val))
         end
-        hyprland.exec_hyprctl_batch(table.unpack(opt_commands))
+        hyprland.hyprctl_batch(table.unpack(opt_commands))
     end
 
     local function restore_windows(activewin_addr)
@@ -210,7 +208,7 @@ return function(args)
             table.insert(commands, string.format("dispatch alterzorder top", activewin_addr))
         end
 
-        hyprland.exec_hyprctl_batch(table.unpack(commands))
+        hyprland.hyprctl_batch(table.unpack(commands))
     end
 
     local function cleanup_and_exit(activewin_addr)

--- a/src/commands/snap.lua
+++ b/src/commands/snap.lua
@@ -21,7 +21,7 @@ return function(args)
     local new_w = math.floor(effective_area.w * (x1_frac - x0_frac))
     local new_h = math.floor(effective_area.h * (y1_frac - y0_frac))
 
-    hyprland.exec_hyprctl_batch(
+    hyprland.hyprctl_batch(
         "dispatch fullscreenstate 0",
         string.format("dispatch moveactive exact %d %d", new_x, new_y),
         string.format("dispatch resizeactive exact %d %d", new_w, new_h),

--- a/src/commands/togglefloat.lua
+++ b/src/commands/togglefloat.lua
@@ -34,7 +34,7 @@ return function(args)
         end
     end
 
-    hyprland.exec_hyprctl_batch(table.unpack(commands))
+    hyprland.hyprctl_batch(table.unpack(commands))
 
     if not is_floating then
         local restore_commands = {}
@@ -51,7 +51,7 @@ return function(args)
         end
 
         if #restore_commands > 0 then
-            hyprland.exec_hyprctl_batch(table.unpack(restore_commands))
+            hyprland.hyprctl_batch(table.unpack(restore_commands))
         end
     end
 end

--- a/src/commands/workspacegroup.lua
+++ b/src/commands/workspacegroup.lua
@@ -39,7 +39,7 @@ return function(args)
             table.insert(commands, "dispatch workspace " .. wsid)
         end
         table.insert(commands, "dispatch focusmonitor " .. active_workspace.monitor)
-        hyprland.exec_hyprctl_batch(table.unpack(commands))
+        hyprland.hyprctl_batch(table.unpack(commands))
 
         -- run custom commands
         for _, cmd in ipairs(cfg.commands) do

--- a/src/commands/workspacegroup.lua
+++ b/src/commands/workspacegroup.lua
@@ -54,9 +54,11 @@ return function(args)
         end
         print(str)
     elseif action == "group" then
-        local group = tonumber(args[2])
-        utils.check_args(not group, "Invalid group number")
-        switch_group(group)
+        local nextgroup = tonumber(args[2])
+        utils.check_args(not nextgroup, "Invalid group number")
+        if group ~= nextgroup then
+            switch_group(nextgroup)
+        end
     else
         local nextgroup = group + (action == "next" and 1 or -1)
         nextgroup = nextgroup > groupcount and groupcount

--- a/src/lib/utils.lua
+++ b/src/lib/utils.lua
@@ -12,12 +12,6 @@ function utils.exec_cmd(cmd)
     return result
 end
 
-function utils.get_cmd_json(command)
-    local output = utils.exec_cmd(command)
-    if output == "" then return {} end
-    return cjson.decode(output)
-end
-
 function utils.fix_color_hex(input)
     -- hyprctl getoption returns colors in legacy format without the leading 0x
     -- but hyprctl keyword doesn't accept that, so we have it back


### PR DESCRIPTION
- **Hyprland API Refactor:**  
  - All commands now interact with Hyprland via native UNIX socket communication rather than shelling out to the `hyprctl` binary.

- **Workspace Group Improvements:**  
  - Extended `workspacegroup.lua` with a new "group" action, allowing direct group selection:  
    `hyprfloat workspaceset <next|prev|status|group>`
