### PR TITLE
v2.5.0

### DIFF
--- a/src/commands/alttab.lua
+++ b/src/commands/alttab.lua
@@ -1,5 +1,6 @@
 local hyprland = require('lib.hyprland')
 local utils = require('lib.utils')
+local config = require('lib.config')
 
 local shared = {}
 
@@ -49,45 +50,60 @@ function shared.activate()
     )
 end
 
+local function mainloop(action, sameclass)
+    -- build list of clients, taking into account whether we are filtering by the sameclass
+    local active_window = hyprland.get_activewindow()
+    local clients = hyprland.get_clients()
+    if sameclass then
+        local active_class = active_window and active_window.class
+        if active_class then
+            local filtered_clients = {}
+            for _, client in ipairs(clients) do
+                if client.class == active_class then
+                    table.insert(filtered_clients, client)
+                end
+            end
+            clients = filtered_clients
+        end
+    end
+
+    -- Sort by focus history and apply direction
+    if #clients > 1 then
+        clients = shared.sort_and_apply_direction(active_window.workspace.id, clients, action)
+    end
+    shared.selected_address = clients[1].address
+
+    -- UI Launcher Mode: Launch the full UI
+    local cfg = config.alttab
+    local luafile = cfg.thumbnails and 'commands.alttab_ui' or 'commands.alttab_ui_lite'
+    local alttab_ui = require(luafile)
+    alttab_ui.launch({ clients = clients, shared = shared })
+end
+
 return {
     run = function(args)
+        if args[1] == "mainloop" then
+            local action = args[2]
+            local sameclass = args[3] == "1"
+            mainloop(action, sameclass)
+            return
+        end
+
         utils.debug("-----")
         utils.debug("alttab started with args: " .. table.concat(args, " "))
-
         utils.check_args(#args < 1, "Usage: hyprfloat alttab <next|prev> [sameclass]")
         local action = args[1]
         local valid = { next = true, prev = true }
         utils.check_args(not valid[action], "Invalid first argument")
 
-        -- build list of clients, taking into account whether we are filtering by the sameclass
-        local has_sameclass = args[2] == "sameclass"
-        local active_window = hyprland.get_activewindow()
-        local clients = hyprland.get_clients()
-        if has_sameclass then
-            local active_class = active_window and active_window.class
-            if active_class then
-                local filtered_clients = {}
-                for _, client in ipairs(clients) do
-                    if client.class == active_class then
-                        table.insert(filtered_clients, client)
-                    end
-                end
-                clients = filtered_clients
-            end
-        end
+        local sameclass = args[2] == "sameclass" and "1" or "0"
+        local me = get_script_root() .. '/hyprfloat'
 
-        -- Sort by focus history and apply direction
-        if #clients > 1 then
-            clients = shared.sort_and_apply_direction(active_window.workspace.id, clients, action)
-        end
-        shared.selected_address = clients[1].address
-
-        -- UI Launcher Mode: Launch the full UI
-        local alttab_ui = require('commands.alttab_ui')
-        alttab_ui.launch({
-            clients = clients,
-            shared = shared
-        })
+        -- call self to run mainloop in new process in case it segfaults
+        hyprland.hyprctl("dispatch submap alttab")
+        local cmd = string.format("lua '%s' alttab mainloop %s %s", me, action, sameclass)
+        os.execute(cmd)
+        hyprland.hyprctl("dispatch submap reset")
     end,
     help = {
         short = "Focuses the next or previous window.",

--- a/src/commands/alttab_ui_lite.lua
+++ b/src/commands/alttab_ui_lite.lua
@@ -1,0 +1,207 @@
+local lgi = require('lgi')
+local Gtk = lgi.require('Gtk', '3.0')
+local Gdk = lgi.require('Gdk', '3.0')
+local GLib = lgi.GLib
+local bit32 = require('bit32')
+local config = require('lib.config')
+local utils = require('lib.utils')
+local hyprland = require('lib.hyprland')
+
+local alttab_ui = {}
+
+local function altkey_down()
+    return bit32.band(Gdk.Keymap.get_default():get_modifier_state(), Gdk.ModifierType.MOD1_MASK) ~= 0
+end
+
+function alttab_ui.launch(params)
+    local shared = params.shared
+    local clients = params.clients
+    local cfg = config.alttab
+
+    local app = Gtk.Application({ application_id = 'hyprfloat.alttab' })
+
+    local all_widgets = {}      -- Flat list of client widgets for easy cycling
+    local widget_to_client = {} -- Map from widget back to client object
+    local current_idx = 1
+
+    function app:on_activate()
+        local window = Gtk.ApplicationWindow {
+            application = app,
+            title = "hyprfloat:alttab"
+        }
+        window:set_name("alttab-window")
+        window:set_decorated(false)
+
+        -- Create a map of monitor IDs to names
+        local monitors = hyprland.get_monitors()
+        local monitor_map = {}
+        for _, mon in ipairs(monitors) do
+            monitor_map[mon.id] = mon.name
+        end
+
+        local outer_box = Gtk.Box {
+            orientation = Gtk.Orientation.VERTICAL,
+            halign = Gtk.Align.CENTER,
+            valign = Gtk.Align.CENTER,
+            spacing = 5
+        }
+        outer_box:set_name("alttab-outer")
+        window:add(outer_box)
+
+        local list_box = Gtk.Box({ orientation = Gtk.Orientation.VERTICAL, spacing = 2 })
+        outer_box:pack_start(list_box, true, true, 0)
+
+        -- Add text entry box at the top
+        local text_entry = Gtk.Entry()
+        text_entry:set_name("alttab-entry")
+        text_entry:set_placeholder_text("Filter...")
+        outer_box:pack_start(text_entry, false, false, 0)
+
+        local list_box = Gtk.Box({ orientation = Gtk.Orientation.VERTICAL, spacing = 2 })
+        outer_box:pack_start(list_box, true, true, 0)
+
+        local active_clients = {}
+        for _, client in ipairs(clients) do
+            if client.workspace.id > 0 then -- Filter out special workspaces
+                table.insert(active_clients, client)
+            end
+        end
+
+        for _, client in ipairs(active_clients) do
+            local mon_name = monitor_map[client.monitor] or "?"
+
+            local grid = Gtk.Grid()
+            grid:set_name("client-row")
+            grid:set_column_spacing(30)
+
+            local app_label = Gtk.Label({ label = client.class .. ": " .. client.title, xalign = 0 })
+            app_label:set_halign(Gtk.Align.START)
+
+            local mon_label = Gtk.Label({ label = "[" .. mon_name .. "]", xalign = 1 })
+            mon_label:set_halign(Gtk.Align.END)
+
+            grid:attach(app_label, 0, 0, 1, 1)
+            grid:attach(mon_label, 1, 0, 1, 1)
+            grid:set_hexpand(true)
+            app_label:set_hexpand(true)
+
+            list_box:pack_start(grid, false, false, 0)
+            table.insert(all_widgets, grid)
+            widget_to_client[grid] = client
+        end
+
+        local function update_selection()
+            if #all_widgets == 0 then
+                shared.selected_address = nil
+                return
+            end
+            for i, widget in ipairs(all_widgets) do
+                if i == current_idx then
+                    widget:get_style_context():add_class("selected")
+                    shared.selected_address = widget_to_client[widget].address
+                else
+                    widget:get_style_context():remove_class("selected")
+                end
+            end
+        end
+
+        local function move_next()
+            if #all_widgets == 0 then return end
+            current_idx = current_idx + 1
+            if current_idx > #all_widgets then current_idx = 1 end
+            update_selection()
+        end
+
+        local function move_prev()
+            if #all_widgets == 0 then return end
+            current_idx = current_idx - 1
+            if current_idx < 1 then current_idx = #all_widgets end
+            update_selection()
+        end
+
+        function window:on_key_press_event(event)
+            local keyval = event.keyval
+            local handled = true
+            if keyval == Gdk.KEY_Escape then
+                app:quit()
+            elseif keyval == Gdk.KEY_Return then
+                shared.activate()
+                app:quit()
+            elseif keyval == Gdk.KEY_Tab or keyval == Gdk.KEY_Down or keyval == Gdk.KEY_Right or keyval == Gdk.KEY_grave then
+                move_next()
+            elseif keyval == Gdk.KEY_ISO_Left_Tab or keyval == Gdk.KEY_Up or keyval == Gdk.KEY_Left then
+                move_prev()
+            else
+                handled = false
+            end
+            return handled
+        end
+
+        -- Apply some styling
+        local css_provider = Gtk.CssProvider()
+        css_provider:load_from_data([[
+            #alttab-window {
+                background-color: rgba(40, 40, 40, 0.9);
+                border-radius: 8px;
+                border: 1px solid rgba(100, 100, 100, 0.8);
+            }
+            #alttab-outer {
+                padding: 10px;
+                min-width: 300px;
+            }
+            #client-row {
+                padding: 2px 5px;
+                border-radius: 4px;
+            }
+            #client-row.selected {
+                background-color: #4A90E2;
+            }
+            #client-row.selected label {
+                color: white;
+            }
+        ]])
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Display.get_default():get_default_screen(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
+        -- Set initial selection and show
+        if #all_widgets > 0 then
+            update_selection()
+        else
+            -- No windows, show a message and quit soon
+            local label = Gtk.Label({ label = "No windows open" })
+            outer_box:pack_start(label, true, true, 0)
+            GLib.timeout_add(GLib.PRIORITY_DEFAULT, 1000, function()
+                app:quit()
+                return false
+            end)
+        end
+
+        window:show_all()
+        window:grab_focus()
+
+        -- Monitor for Alt key release to activate window
+        GLib.timeout_add(GLib.PRIORITY_DEFAULT, cfg.altkey_wait_ms or 100, function()
+            if altkey_down() then
+                return true -- Continue monitoring
+            end
+            utils.debug("ALT Key released")
+            app:quit()
+            if shared.selected_address then
+                shared.activate()
+            end
+            return false -- Stop timer
+        end)
+    end
+
+    local success, err = pcall(function()
+        app:run(nil)
+    end)
+    if not success then
+        utils.debug("Error running alttab_ui: " .. tostring(err))
+    end
+end
+
+return alttab_ui

--- a/src/commands/dynamicbind.lua
+++ b/src/commands/dynamicbind.lua
@@ -1,8 +1,32 @@
+local hyprland = require("lib.hyprland")
+local utils = require("lib.utils")
+
+local function run_cmd(cmd)
+    utils.debug(cmd)
+
+    local delim1_start, delim1_end = string.find(cmd, ":")
+    if not delim1_start then
+        hyprland.hyprctl(cmd)
+    else
+        local cmdline = string.sub(cmd, delim1_end + 1)
+        local delimc1_start, delimc1_end = string.find(cmdline, " ")
+        local command_name = ""
+        local args = {}
+        if not delim1_start then
+            command_name = cmdline
+        else
+            command_name = string.sub(cmdline, 1, delimc1_start - 1)
+            args = utils.explode("%S+", string.sub(cmdline, delimc1_end + 1))
+        end
+
+        local ok, command = pcall(require, "commands." .. command_name)
+        command.run(args)
+    end
+end
+
 return {
     run = function(args)
-        local hyprland = require("lib.hyprland")
         local config = require("lib.config")
-        local utils = require("lib.utils")
         local cfg = config.dynamic_bind
 
         utils.check_args(#args ~= 1, "Usage: hyprfloat dynamic_bind <command>")
@@ -10,12 +34,14 @@ return {
         local win = hyprland.get_activewindow()
         utils.check_args(not win, "No active window")
 
-        local mode = win.floating and "floating" or "tiling"
         local bind = args[1]
+        local mode = utils.file_exists(utils.runtime_path("/overview.sock")) and "overview"
+            or win.floating and "floating"
+            or "tiling"
         local cmd = cfg[mode][bind]
+
         if cmd then
-            utils.debug(cmd)
-            hyprland.hyprctl(cmd)
+            run_cmd(cmd)
         end
     end,
     help = {

--- a/src/commands/movefocus.lua
+++ b/src/commands/movefocus.lua
@@ -1,0 +1,101 @@
+return {
+    run = function(args)
+        local hyprland = require("lib.hyprland")
+        local utils = require("lib.utils")
+
+        utils.check_args(#args ~= 1, "Usage: hyprfloat movefocus [u|d|l|r]")
+
+        local direction = args[1]:lower()
+
+        utils.check_args(not direction:match("^[udlr]$"), "Direction must be u)p, d)own, l)eft, or r)ight")
+
+        local ctx = hyprland.get_active_context()
+        if not ctx or not ctx.window then
+            utils.check_args(true, "No active window/monitor context")
+            return
+        end
+
+        local current_window = ctx.window
+        local current_workspace_id = hyprland.get_activeworkspace().id
+
+        local floating_windows = {}
+        for _, client in ipairs(hyprland.get_clients()) do
+            if client.floating and client.workspace.id == current_workspace_id then
+                table.insert(floating_windows, client)
+            end
+        end
+
+        utils.check_args(#floating_windows <= 1, "No other floating windows to focus")
+
+        local current_x = current_window.at[1] + current_window.size[1] * 0.5
+        local current_y = current_window.at[2] + current_window.size[2] * 0.5
+        local current_addr = current_window.address
+
+        local best_window = nil
+
+        if direction == "l" or direction == "r" then
+            table.sort(floating_windows, function(a, b)
+                local a_y = a.at[2] + a.size[2] * 0.5
+                local b_y = b.at[2] + b.size[2] * 0.5
+                if math.abs(a_y - b_y) > 10 then
+                    return a_y < b_y
+                end
+                return a.at[1] + a.size[1] * 0.5 < b.at[1] + b.size[1] * 0.5
+            end)
+        else
+            table.sort(floating_windows, function(a, b)
+                local a_x = a.at[1] + a.size[1] * 0.5
+                local b_x = b.at[1] + b.size[1] * 0.5
+                if math.abs(a_x - b_x) > 10 then
+                    return a_x < b_x
+                end
+                return a.at[2] + a.size[2] * 0.5 < b.at[2] + b.size[2] * 0.5
+            end)
+        end
+
+        local current_idx = 1
+        for i, win in ipairs(floating_windows) do
+            if win.address == current_addr then
+                current_idx = i
+                break
+            end
+        end
+
+        local target_idx
+        if direction == "r" or direction == "d" then
+            target_idx = current_idx % #floating_windows + 1
+        else
+            target_idx = current_idx == 1 and #floating_windows or current_idx - 1
+        end
+        best_window = floating_windows[target_idx]
+
+        if best_window then
+            hyprland.hyprctl_batch(
+                string.format("dispatch focuswindow address:%s", best_window.address),
+                "dispatch alterzorder top"
+            )
+        end
+    end,
+    help = {
+        short = "Move floating window focus by proximity with wrapping.",
+        usage = "movefocus <direction>",
+        long = [[
+Move floating window focus by proximity in a given direction with wrapping support.
+
+The algorithm treats floating windows as positioned in a 2D matrix and finds the nearest window in the specified direction. If no window exists in that direction, it wraps around to the opposite side.
+
+**Arguments:**
+- `<direction>` Required. Direction to move focus:
+  - `u` - Focus nearest window above (wraps to bottom)
+  - `d` - Focus nearest window below (wraps to top)
+  - `l` - Focus nearest window to the left (wraps to right)
+  - `r` - Focus nearest window to the right (wraps to left)
+
+**Behavior:**
+- Only considers floating windows on the current workspace
+- Uses window center points for distance calculations
+- Prioritizes windows in the target direction, then falls back to wrapping
+- Secondary sorting by distance for tie-breaking
+]]
+    }
+}

--- a/src/commands/movemon.lua
+++ b/src/commands/movemon.lua
@@ -73,6 +73,7 @@ return {
             "dispatch fullscreenstate 0",
             string.format("dispatch moveactive exact %d %d", new_x, new_y),
             string.format("dispatch resizeactive exact %d %d", new_w, new_h),
+            string.format("dispatch focuswindow address:%s", old.address),
             "dispatch alterzorder top"
         )
     end,

--- a/src/commands/togglefloat.lua
+++ b/src/commands/togglefloat.lua
@@ -35,11 +35,13 @@ return {
         end
 
         local commands = {}
-        local rule = is_floating and "unset" or "float"
-        local cmd = string.format('keyword windowrule %s,workspace:%d', rule, active_workspace_id)
-        utils.debug(cmd)
-        table.insert(commands, cmd)
-
+        if is_floating then
+            table.insert(commands, string.format('keyword windowrule unset,workspace:%d', active_workspace_id))
+            table.insert(commands, string.format('keyword windowrule unset,class:.*'))
+        else
+            table.insert(commands, string.format('keyword windowrule float,workspace:%d', active_workspace_id))
+            table.insert(commands, string.format('keyword windowrule float,class:.*'))
+        end
 
         local mode_commands = is_floating and cfg.tiling_commands or cfg.floating_commands
         for _, cmd in ipairs(mode_commands) do

--- a/src/config/default.conf.lua
+++ b/src/config/default.conf.lua
@@ -26,17 +26,23 @@ return {
     },
 
     dynamic_bind = {
+        overview = {
+            SUPER_LEFT  = 'hyprfloat:movefocus l',
+            SUPER_RIGHT = 'hyprfloat:movefocus r',
+            SUPER_UP    = 'hyprfloat:movefocus u',
+            SUPER_DOWN  = 'hyprfloat:movefocus d'
+        },
         tiling = {
-            SUPER_LEFT = 'dispatch movefocus l',
+            SUPER_LEFT  = 'dispatch movefocus l',
             SUPER_RIGHT = 'dispatch movefocus r',
-            SUPER_UP = 'dispatch movefocus u',
-            SUPER_DOWN = 'dispatch movefocus d'
+            SUPER_UP    = 'dispatch movefocus u',
+            SUPER_DOWN  = 'dispatch movefocus d'
         },
         floating = {
-            SUPER_LEFT = 'dispatch exec hyprfloat snap 0.0 0.5 0.0 1.0',
-            SUPER_RIGHT = 'dispatch exec hyprfloat snap 0.5 1.0 0.0 1.0',
-            SUPER_UP = 'dispatch exec hyprfloat center 1.25',
-            SUPER_DOWN = 'dispatch exec hyprfloat center 0.75',
+            SUPER_LEFT  = 'hyprfloat:snap 0.0 0.5 0.0 1.0',
+            SUPER_RIGHT = 'hyprfloat:snap 0.5 1.0 0.0 1.0',
+            SUPER_UP    = 'hyprfloat:center 1.25',
+            SUPER_DOWN  = 'hyprfloat:center 0.75',
         },
     },
 
@@ -63,6 +69,9 @@ return {
         -- Milliseconds to wait before opening the main selector window.
         mainwindow_wait_ms = 100,
 
+        -- Show thumbnails (slower)
+        thumbnails = false,
+
         -- Number of concurrent grim processes to run
         max_concurrent = 8,
 
@@ -73,41 +82,42 @@ return {
         default_monitor_index = 0,
 
         -- Tile dimensions
-        base_tile_size = 240,
-        selected_tile_size = 280,
-        tile_container_size = 300,
+        base_tile_size = 160,
+        selected_tile_size = 180,
+        tile_container_size = 190,
 
         -- Grid spacing
         grid_row_spacing = 5,
         grid_column_spacing = 5,
 
         -- Window layout
-        window_margin_top = 20,
-        window_margin_bottom = 20,
-        window_margin_left = 20,
-        window_margin_right = 20,
+        window_margin_top = 10,
+        window_margin_bottom = 10,
+        window_margin_left = 10,
+        window_margin_right = 10,
 
         -- Window stylesheet
         stylesheet = [[
             #alttab-window {
                 background: rgba(30, 30, 30, .75);
             }
+            #alttab-outer {
+                padding:10px;
+            }
             .tile {
                 background-color: transparent;
-                border: 1px solid transparent;
-                border-radius: 4px;
-                padding: 4px;
             }
             .tile.selected {
                 background-color: rgba(100, 200, 255, .30);
                 border: 3px solid #33ccff;
                 border-radius: 8px;
-                padding: 4px;
             }
             #search {
                 border: 1px solid #c0c0c0;
+                margin-bottom:20px;
             }
             #label1 {
+                margin-top:20px;
                 color: #ddeeff;
                 font-size: 16px;
                 font-weight: bold;

--- a/src/config/hyprfloat.conf
+++ b/src/config/hyprfloat.conf
@@ -1,7 +1,8 @@
 # Settings for ALT-Tab
 #
 submap = alttab
-bind   = SHIFT, SPACE, exec, hyprctl dispatch submap reset
+bind = , ALT_L, submap, reset
+bind = , ESC, submap, reset
 submap = reset
 bind = ALT, TAB,               exec, hyprfloat alttab next
 bind = ALT_SHIFT, TAB,         exec, hyprfloat alttab prev

--- a/src/lib/manifest.lua
+++ b/src/lib/manifest.lua
@@ -1,11 +1,12 @@
 return {
-    version = "2.0.1",
+    version = "2.5.0",
     commands = {
         "alttab",
         "center",
         "dynamicbind",
         "events",
         "install-config",
+        "movefocus",
         "movemon",
         "overview",
         "snap",

--- a/src/lib/utils.lua
+++ b/src/lib/utils.lua
@@ -118,4 +118,12 @@ function utils.file_exists(name)
     return result == true or result == 0
 end
 
+function utils.explode(delim, input)
+    local t = {}
+    for word in string.gmatch(input, delim) do
+        table.insert(t, word)
+    end
+    return t
+end
+
 return utils


### PR DESCRIPTION
This commit introduces significant enhancements to the Alt-Tab functionality, adds a new command for navigating floating windows, and improves the flexibility of dynamic binds.

Alt-Tab UI Revamp:

• Lightweight UI by default: A new alttab_ui_lite is introduced, providing a faster, text-based Alt-Tab experience without thumbnails. This is now the default (config.alttab.thumbnails = false).
• Thumbnail UI option: The original alttab_ui (with thumbnails) can be re-enabled via config.alttab.thumbnails = true.
• Improved stability: The Alt-Tab UI is now launched in a separate process (os.execute) to prevent Hyprland from freezing if the UI process encounters issues.
• Refined submap handling: Alt-Tab submap activation and reset are now managed more robustly within the alttab command.
• Configurable appearance: Default tile sizes and margins for the thumbnail UI have been adjusted for a more compact look.

Floating Window Navigation (movefocus):

• New movefocus command: Allows cycling focus between floating windows on the current workspace in a given direction (up, down, left, right) with wrapping.
• Integrated into dynamic_bind: movefocus is now the default action for SUPER_LEFT/RIGHT/UP/DOWN when in overview mode.

Dynamic Bind Enhancements:

• Internal command execution: dynamicbind now supports executing internal hyprfloat commands (e.g., hyprfloat:snap) directly from the configuration, offering greater flexibility.
• overview mode: A new overview mode is added to dynamic_bind, allowing different keybinds when the overview is active.
• Updated default binds: dynamic_bind.floating commands now use the hyprfloat: prefix.

Other Notable Changes:

• togglefloat rule application: togglefloat now applies float or unset window rules to class:.* in addition to workspace:%d, making the rule more general.
• movemon focus: Ensures the moved window retains focus after being moved to another monitor.
• Version bump: Updated hyprfloat version to 2.5.0.